### PR TITLE
Exclude 403-inaccessible streams from discovery & move parameterized to dev deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: "Setup virtual env"
           command: |
-            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-zoho-crm
+            uv venv --python 3.12 /usr/local/share/virtualenvs/tap-zoho-crm
             source /usr/local/share/virtualenvs/tap-zoho-crm/bin/activate
             uv pip install -U setuptools
             uv pip install .[dev]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,10 @@ jobs:
       - run:
           name: "Integration Tests"
           command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            uv pip install --upgrade awscli
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
             unset USE_STITCH_BACKEND
             run-test --tap=tap-zoho-crm tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,13 +35,14 @@ jobs:
           path: test_output/report.xml
       - store_artifacts:
           path: htmlcov
-      # - run:
-      #     name: "Integration Tests"
-      #     command: |
-      #       aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
-      #       source dev_env.sh
-      #       source /usr/local/share/virtualenvs/tap-tester/bin/activate
-      #       run-test --tap=tap-zoho-crm tests
+      - run:
+          name: "Integration Tests"
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            unset USE_STITCH_BACKEND
+            run-test --tap=tap-zoho-crm tests
 
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 0.0.2
+  * Bump requests to 2.33.0 (CVE-2026-25645)
+
 ## 0.0.1
   * Initial Commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 0.0.2
-  * Bump requests to 2.33.0 (CVE-2026-25645)
+## 0.1.0
+  * 403-inaccessible streams are now excluded from the catalog during discovery instead of failing entirely. [#9](https://github.com/singer-io/tap-zoho-crm/pull/9)
+  * Added unit tests for discovery access-check behavior.
+  * Bump singer-python to 6.8.0 and requests to 2.34.2 (CVE-2026-25645)
 
 ## 0.0.1
   * Initial Commit

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-zoho-crm",
-      version="0.0.1",
+      version="0.0.2",
       description="Singer.io tap for extracting data from Zoho-CRM API",
       author="Stitch",
       url="http://singer.io",
@@ -12,7 +12,7 @@ setup(name="tap-zoho-crm",
       py_modules=["tap_zoho_crm"],
       install_requires=[
         "singer-python==6.1.1",
-        "requests==2.32.4",
+        "requests==2.33.0",
         "backoff==2.2.1",
       ],
       extras_require={"dev": ["parameterized==0.9.0", "pylint", "ipdb", "pytest"]},

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,15 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-zoho-crm",
-      version="0.0.2",
+      version="0.1.0",
       description="Singer.io tap for extracting data from Zoho-CRM API",
       author="Stitch",
       url="http://singer.io",
       classifiers=["Programming Language :: Python :: 3 :: Only"],
       py_modules=["tap_zoho_crm"],
       install_requires=[
-        "singer-python==6.1.1",
-        "requests==2.33.0",
+        "singer-python==6.8.0",
+        "requests==2.34.2",
         "backoff==2.2.1",
       ],
       extras_require={"dev": ["parameterized==0.9.0", "pylint", "ipdb", "pytest"]},

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,8 @@ setup(name="tap-zoho-crm",
         "singer-python==6.1.1",
         "requests==2.32.4",
         "backoff==2.2.1",
-        "parameterized==0.9.0"
       ],
-      extras_require={"dev": ["pylint", "ipdb", "pytest"]},
+      extras_require={"dev": ["parameterized==0.9.0", "pylint", "ipdb", "pytest"]},
       entry_points="""
           [console_scripts]
           tap-zoho-crm=tap_zoho_crm:main

--- a/tap_zoho_crm/client.py
+++ b/tap_zoho_crm/client.py
@@ -86,14 +86,19 @@ def raise_for_error(response: requests.Response) -> None:
     raise exception_class(message, response) from None
 
 
-def wait_if_retry_after(details):
-    """Backoff handler that checks for a 'retry_after' attribute in the exception
-    and sleeps for the specified duration to respect API rate limits.
+def get_retry_after(exception_info):
+    """Returns the retry_after value from RateLimitError exception.
+    This is used by backoff.runtime to determine wait time.
     """
-    exc = details['exception']
-    if hasattr(exc, 'retry_after') and exc.retry_after is not None:
-        LOGGER.warning(f"Rate limited. Retrying in {exc.retry_after} seconds...")
-        time.sleep(exc.retry_after)
+    exception = exception_info.get('exception') if isinstance(exception_info, dict) else exception_info
+
+    if exception and isinstance(exception, ZohoCRMRateLimitError):
+        retry_after = exception.retry_after if hasattr(exception, 'retry_after') \
+                        and exception.retry_after is not None else 60
+        LOGGER.info(f"Rate limited. Waiting {retry_after} seconds...")
+        return retry_after
+
+    return 60  # Default fallback
 
 class Client:
     """
@@ -222,13 +227,13 @@ class Client:
         factor=2
     )
     @backoff.on_exception(
-        wait_gen=backoff.constant,
-        on_backoff=wait_if_retry_after,
+        backoff.runtime,
         exception=(
             ZohoCRMRateLimitError,
         ),
         max_tries=5,
-        interval=1
+        value=get_retry_after,
+        jitter=None
     )
     def __make_request(
         self, method: str, endpoint: str, **kwargs

--- a/tap_zoho_crm/discover.py
+++ b/tap_zoho_crm/discover.py
@@ -32,16 +32,14 @@ def _apply_access_checks(client: Client, schemas: dict, field_metadata: dict) ->
 
     _prune_inaccessible_children(schemas, field_metadata)
 
-    if inaccessible_streams:
-        total_parent_streams = len([s for s in STREAMS.values() if not s.parent])
-        if len(inaccessible_streams) == total_parent_streams:
-            raise ZohoCRMForbiddenError(
-                "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
-                "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
-            )
+    if not schemas:
+        raise ZohoCRMForbiddenError(
+            "HTTP-error-code: 403, Error: The credentials do not \
+                have 'read' access to any supported streams."
+        )
+    elif inaccessible_streams:
         LOGGER.warning(
-            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
-            "These streams have been excluded from the catalog.",
+            "No 'read' access to stream(s): %s. Excluded from catalog.",
             ", ".join(inaccessible_streams),
         )
 
@@ -54,7 +52,8 @@ def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
     for name, stream_cls in list(STREAMS.items()):
         if name in schemas and stream_cls.parent and stream_cls.parent not in schemas:
             LOGGER.warning(
-                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                "Stream '%s' excluded from catalog because its \
+                    parent stream '%s' is not accessible.",
                 name, stream_cls.parent,
             )
             schemas.pop(name, None)

--- a/tap_zoho_crm/discover.py
+++ b/tap_zoho_crm/discover.py
@@ -4,19 +4,76 @@ from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_zoho_crm.schema import get_static_schemas, get_dynamic_schema
 from tap_zoho_crm.client import Client
+from tap_zoho_crm.streams import STREAMS
+from tap_zoho_crm.exceptions import ZohoCRMForbiddenError
 
 LOGGER = singer.get_logger()
+
+
+def _apply_access_checks(client: Client, schemas: dict, field_metadata: dict) -> None:
+    """
+    Probe each stream for read access and remove inaccessible streams
+    (and their children) from schemas and field_metadata in place.
+    Note: check_access() always returns True for child streams, so this loop
+    effectively identifies only inaccessible parent streams by design.
+    Child stream removal is handled separately by _prune_inaccessible_children().
+    Raises ZohoCRMForbiddenError if no parent streams are accessible.
+    """
+    inaccessible_streams = [
+        stream_name
+        for stream_name, stream_obj in STREAMS.items()
+        if stream_name in schemas
+        and not stream_obj(client=client).check_access()
+    ]
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
+
+    _prune_inaccessible_children(schemas, field_metadata)
+
+    if inaccessible_streams:
+        total_parent_streams = len([s for s in STREAMS.values() if not s.parent])
+        if len(inaccessible_streams) == total_parent_streams:
+            raise ZohoCRMForbiddenError(
+                "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
+                "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
+            )
+        LOGGER.warning(
+            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
+            "These streams have been excluded from the catalog.",
+            ", ".join(inaccessible_streams),
+        )
+
+
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+    """
+    Remove child streams from the catalog whose parent stream was excluded.
+    Mutates schemas and field_metadata in place.
+    """
+    for name, stream_cls in list(STREAMS.items()):
+        if name in schemas and stream_cls.parent and stream_cls.parent not in schemas:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                name, stream_cls.parent,
+            )
+            schemas.pop(name)
+            field_metadata.pop(name)
 
 
 def discover(client: Client) -> Catalog:
     """
     Run the discovery mode, prepare the catalog file and return the catalog.
+    Access to each stream is verified using the provided client and streams
+    the credentials cannot read are excluded from the returned catalog.
     """
     static_schemas, static_field_metadata = get_static_schemas()
     dynamic_schemas, dynamic_field_metadata = get_dynamic_schema(client)
 
     schemas = static_schemas | dynamic_schemas
     field_metadata = static_field_metadata | dynamic_field_metadata
+
+    _apply_access_checks(client, schemas, field_metadata)
 
     catalog = Catalog([])
 

--- a/tap_zoho_crm/discover.py
+++ b/tap_zoho_crm/discover.py
@@ -57,8 +57,8 @@ def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
                 "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
                 name, stream_cls.parent,
             )
-            schemas.pop(name)
-            field_metadata.pop(name)
+            schemas.pop(name, None)
+            field_metadata.pop(name, None)
 
 
 def discover(client: Client) -> Catalog:

--- a/tap_zoho_crm/streams/abstracts.py
+++ b/tap_zoho_crm/streams/abstracts.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import json
 from typing import Any, Dict, Tuple, List, Iterator
+from tap_zoho_crm.exceptions import ZohoCRMForbiddenError
 from singer import (
     Transformer,
     get_bookmark,
@@ -46,8 +47,8 @@ class BaseStream(ABC):
     def __init__(self, client=None, catalog=None) -> None:
         self.client = client
         self.catalog = catalog
-        self.schema = catalog.schema.to_dict()
-        self.metadata = metadata.to_map(catalog.metadata)
+        self.schema = catalog.schema.to_dict() if catalog else {}
+        self.metadata = metadata.to_map(catalog.metadata) if catalog else {}
         self.child_to_sync = []
         self.params = {}
         self.data_payload = {}
@@ -196,6 +197,34 @@ class BaseStream(ABC):
         Modify the record before writing to the stream
         """
         return record
+
+    def check_access(self) -> bool:
+        """
+        Verify that the API credentials have read access to this stream.
+        Returns True if accessible, False if a 403 Forbidden error is raised.
+        Child streams always return True (access is governed by the parent check).
+        This means children are never flagged by the access-check loop in _apply_access_checks();
+        their removal from the catalog is handled separately by _prune_inaccessible_children().
+        """
+        if self.parent:
+            return True
+
+        try:
+            self.client.make_request(
+                self.http_method,
+                self.url_endpoint,
+                self.params,
+                self.headers,
+                body=json.dumps(self.data_payload),
+                path=self.path,
+            )
+            return True
+        except ZohoCRMForbiddenError:
+            LOGGER.warning(
+                "Stream '%s' does not have read permission, excluding from catalog.",
+                self.__class__.__name__,
+            )
+            return False
 
     def get_url_endpoint(self, parent_obj: Dict = None) -> str:
         """

--- a/tap_zoho_crm/streams/abstracts.py
+++ b/tap_zoho_crm/streams/abstracts.py
@@ -221,10 +221,11 @@ class BaseStream(ABC):
                 path=self.path,
             )
             return True
-        except ZohoCRMForbiddenError:
+        except ZohoCRMForbiddenError as exc:
             LOGGER.warning(
-                "Stream '%s' does not have read permission, excluding from catalog.",
+                "Permission Error: Stream '%s' %s. Excluding from catalog.",
                 self.__class__.__name__,
+                exc,
             )
             return False
 

--- a/tap_zoho_crm/streams/abstracts.py
+++ b/tap_zoho_crm/streams/abstracts.py
@@ -52,6 +52,8 @@ class BaseStream(ABC):
         self.child_to_sync = []
         self.params = {}
         self.data_payload = {}
+        if client and client.config.get('page_size'):
+            self.page_size = int(client.config['page_size'])
 
     @property
     @abstractmethod

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,23 +1,18 @@
-import copy
 import os
-import unittest
-from datetime import datetime as dt
-from datetime import timedelta
 
-import dateutil.parser
-import pytz
-from tap_tester import connections, menagerie, runner
 from tap_tester.logger import LOGGER
 from tap_tester.base_suite_tests.base_case import BaseCase
 
 
-class Zoho_CRMBaseTest(BaseCase):
+
+class ZohoCRMBaseTest(BaseCase):
     """Setup expectations for test sub classes.
 
     Metadata describing streams. A bunch of shared methods that are used
     in tap-tester tests. Shared tap-specific methods (as needed).
     """
-    start_date = "2019-01-01T00:00:00Z"
+    start_date = "2025-01-01T00:00:00Z"
+    IS_FORBIDDEN_STREAM = "is-forbidden-stream"
 
     @staticmethod
     def tap_name():
@@ -38,42 +33,42 @@ class Zoho_CRMBaseTest(BaseCase):
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "modified_time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "organization": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.FULL_TABLE,
                 cls.REPLICATION_KEYS: set(),
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "profiles": {
                 cls.PRIMARY_KEYS: { "id" },
-                cls.REPLICATION_METHOD: cls.INCREMENTAL,
-                cls.REPLICATION_KEYS: { "modified_time" },
+                cls.REPLICATION_METHOD: cls.FULL_TABLE,
+                cls.REPLICATION_KEYS: set(),
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "roles": {
                 cls.PRIMARY_KEYS: { "id" },
-                cls.REPLICATION_METHOD: cls.INCREMENTAL,
-                cls.REPLICATION_KEYS: { "modified_time__s" },
+                cls.REPLICATION_METHOD: cls.FULL_TABLE,
+                cls.REPLICATION_KEYS: set(),
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "territories": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "modified_time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "users": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "Modified_Time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             # Dynamic Schemas for testing
             "leads": {
@@ -81,91 +76,92 @@ class Zoho_CRMBaseTest(BaseCase):
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "Modified_Time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "accounts": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "Modified_Time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "calls": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "Modified_Time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "tasks": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "Modified_Time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "campaigns": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "Modified_Time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "deals": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "Modified_Time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "notes": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "Modified_Time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "dealhistory": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "Modified_Time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "attachments": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "Modified_Time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "contacts": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "Modified_Time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "appointments_rescheduled_history__s": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "Modified_Time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5,
+                cls.IS_FORBIDDEN_STREAM: True
             },
             "functions__s": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "modified_time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             },
             "events": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: { "Modified_Time" },
                 cls.OBEYS_START_DATE: False,
-                cls.API_LIMIT: 200
+                cls.API_LIMIT: 5
             }
         }
 
@@ -184,10 +180,19 @@ class Zoho_CRMBaseTest(BaseCase):
 
         return credentials_dict
 
+    def expected_stream_names(self):
+        """The expected stream names and exclude forbidden streams."""
+        return {
+            stream_name
+            for stream_name, metadata in self.expected_metadata().items()
+            if not metadata.get(self.IS_FORBIDDEN_STREAM, False)
+        }
+
     def get_properties(self, original: bool = True):
         """Configuration of properties required for the tap."""
         return_value = {
-            "start_date": "2022-07-01T00:00:00Z"
+            "start_date": self.start_date,
+            "page_size": "5"
         }
         if original:
             return return_value

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -1,12 +1,10 @@
-from base import Zoho_CRMBaseTest
+from base import ZohoCRMBaseTest
 from tap_tester.base_suite_tests.all_fields_test import AllFieldsTest
 
-KNOWN_MISSING_FIELDS = {
-
-}
+KNOWN_MISSING_FIELDS = {}
 
 
-class Zoho_CRMAllFields(AllFieldsTest, Zoho_CRMBaseTest):
+class ZohoCRMAllFields(AllFieldsTest, ZohoCRMBaseTest):
     """Ensure running the tap with all streams and fields selected results in
     the replication of all fields."""
 
@@ -17,8 +15,7 @@ class Zoho_CRMAllFields(AllFieldsTest, Zoho_CRMBaseTest):
     def streams_to_test(self):
         # excluding dynamic schemas due to lack of test data
         streams_to_exclude = {
-            'Appointments_Rescheduled_History__s',
-            'territories'
+            'territories',
+            'functions__s'
         }
         return self.expected_stream_names().difference(streams_to_exclude)
-

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -1,10 +1,10 @@
 """Test that with no fields selected for a stream automatic fields are still
 replicated."""
-from base import Zoho_CRMBaseTest
+from base import ZohoCRMBaseTest
 from tap_tester.base_suite_tests.automatic_fields_test import MinimumSelectionTest
 
 
-class Zoho_CRMAutomaticFields(MinimumSelectionTest, Zoho_CRMBaseTest):
+class ZohoCRMAutomaticFields(MinimumSelectionTest, ZohoCRMBaseTest):
     """Test that with no fields selected for a stream automatic fields are
     still replicated."""
 
@@ -15,8 +15,7 @@ class Zoho_CRMAutomaticFields(MinimumSelectionTest, Zoho_CRMBaseTest):
     def streams_to_test(self):
         # excluding dynamic schemas due to lack of test data
         streams_to_exclude = {
-            'Appointments_Rescheduled_History__s',
-            'territories'
+            'territories',
+            'functions__s'
         }
         return self.expected_stream_names().difference(streams_to_exclude)
-

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -1,25 +1,41 @@
-from base import Zoho_CRMBaseTest
+from base import ZohoCRMBaseTest
 from tap_tester.base_suite_tests.bookmark_test import BookmarkTest
 
 
-class Zoho_CRMBookMarkTest(BookmarkTest, Zoho_CRMBaseTest):
+class ZohoCRMBookMarkTest(BookmarkTest, ZohoCRMBaseTest):
     """Test tap sets a bookmark and respects it for the next sync of a
     stream."""
     bookmark_format = "%Y-%m-%dT%H:%M:%S.%fZ"
     initial_bookmarks = {
         "bookmarks": {
-            "currencies": { "modified_time" : "2020-01-01T00:00:00Z"},
-            "profiles": { "modified_time" : "2020-01-01T00:00:00Z"},
-            "roles": { "modified_time__s" : "2020-01-01T00:00:00Z"},
-            "territories": { "modified_time" : "2020-01-01T00:00:00Z"},
-            "users": { "Modified_Time" : "2020-01-01T00:00:00Z"},
+            "leads":       {"Modified_Time": "2025-08-01T00:00:00Z"},
+            "contacts":    {"Modified_Time": "2025-08-01T00:00:00Z"},
+            "accounts":    {"Modified_Time": "2025-08-01T00:00:00Z"},
+            "deals":       {"Modified_Time": "2025-08-01T00:00:00Z"},
+            "calls":       {"Modified_Time": "2025-08-01T00:00:00Z"},
+            "campaigns":   {"Modified_Time": "2025-08-01T00:00:00Z"},
+            "dealhistory": {"Modified_Time": "2025-08-01T00:00:00Z"},
+            "attachments": {"Modified_Time": "2025-08-01T00:00:00Z"},
         }
     }
+
     @staticmethod
     def name():
         return "tap_tester_zoho_crm_bookmark_test"
 
     def streams_to_test(self):
-        streams_to_exclude = {}
+        streams_to_exclude = {
+            'territories',
+            'functions__s',
+            # FULL_TABLE, no replication key
+            'organization',
+            'profiles',
+            'roles',
+            # lack of sufficient test data to verify bookmark behavior
+            'currencies',
+            'tasks',
+            'notes',
+            'events',
+            'users'
+        }
         return self.expected_stream_names().difference(streams_to_exclude)
-

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,9 +1,9 @@
 """Test tap discovery mode and metadata."""
-from base import Zoho_CRMBaseTest
+from base import ZohoCRMBaseTest
 from tap_tester.base_suite_tests.discovery_test import DiscoveryTest
 
 
-class Zoho_CRMDiscoveryTest(DiscoveryTest, Zoho_CRMBaseTest):
+class ZohoCRMDiscoveryTest(DiscoveryTest, ZohoCRMBaseTest):
     """Test tap discovery mode and metadata conforms to standards."""
 
     @staticmethod
@@ -14,4 +14,3 @@ class Zoho_CRMDiscoveryTest(DiscoveryTest, Zoho_CRMBaseTest):
         # excluding dynamic schemas
         streams_to_exclude = {}
         return self.expected_stream_names().difference(streams_to_exclude)
-

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -1,9 +1,9 @@
 
-from base import Zoho_CRMBaseTest
+from base import ZohoCRMBaseTest
 from tap_tester.base_suite_tests.interrupted_sync_test import InterruptedSyncTest
 
 
-class Zoho_CRMInterruptedSyncTest(Zoho_CRMBaseTest):
+class ZohoCRMInterruptedSyncTest(InterruptedSyncTest, ZohoCRMBaseTest):
     """Test tap sets a bookmark and respects it for the next sync of a
     stream."""
 
@@ -12,20 +12,26 @@ class Zoho_CRMInterruptedSyncTest(Zoho_CRMBaseTest):
         return "tap_tester_zoho_crm_interrupted_sync_test"
 
     def streams_to_test(self):
-        return self.expected_stream_names()
+        # excluding streams because no data and full table replication method
+        streams_to_exclude = {
+            'territories',
+            'functions__s',
+            'organization',
+            'profiles',
+            'roles',
+            'currencies'
+        }
+        return self.expected_stream_names().difference(streams_to_exclude)
 
 
     def manipulate_state(self):
         return {
-            "currently_syncing": "prospects",
+            "currently_syncing": "deals",
             "bookmarks": {
-                "appointments": { "Modified_Time" : "2020-01-01T00:00:00Z"},
-                "currencies": { "modified_time" : "2020-01-01T00:00:00Z"},
-                "profiles": { "modified_time" : "2020-01-01T00:00:00Z"},
-                "roles": { "modified_time__s" : "2020-01-01T00:00:00Z"},
-                "services": { "Modified_Time" : "2020-01-01T00:00:00Z"},
-                "territories": { "modified_time" : "2020-01-01T00:00:00Z"},
-                "users": { "Modified_Time" : "2020-01-01T00:00:00Z"},
+                "users": {"Modified_Time": "2025-09-16T02:42:47.000000Z"},
+                "leads": {"Modified_Time": "2026-06-03T09:12:54.000000Z"},
+                "contacts": {"Modified_Time": "2025-09-16T02:23:30.000000Z"},
+                "accounts": {"Modified_Time": "2025-09-16T02:25:23.000000Z"},
+                "deals": {"Modified_Time": "2025-09-01T00:00:00.000000Z"},
+            }
         }
-    }
-

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,7 +1,7 @@
 from tap_tester.base_suite_tests.pagination_test import PaginationTest
-from base import Zoho_CRMBaseTest
+from base import ZohoCRMBaseTest
 
-class Zoho_CRMPaginationTest(PaginationTest, Zoho_CRMBaseTest):
+class ZohoCRMPaginationTest(PaginationTest, ZohoCRMBaseTest):
     """
     Ensure tap can replicate multiple pages of data for streams that use pagination.
     """
@@ -11,6 +11,17 @@ class Zoho_CRMPaginationTest(PaginationTest, Zoho_CRMBaseTest):
         return "tap_tester_zoho_crm_pagination_test"
 
     def streams_to_test(self):
-        streams_to_exclude = {}
+        # Exclude streams that don't have enough test data to exceed the page_size
+        streams_to_exclude = {
+            'territories',
+            'functions__s',
+            'currencies',
+            'organization',
+            'profiles',
+            'roles',
+            'users',
+            'calls',
+            'campaigns',
+            'attachments'
+        }
         return self.expected_stream_names().difference(streams_to_exclude)
-

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -1,9 +1,9 @@
-from base import Zoho_CRMBaseTest
+from base import ZohoCRMBaseTest
 from tap_tester.base_suite_tests.start_date_test import StartDateTest
 
 
 
-class Zoho_CRMStartDateTest(StartDateTest, Zoho_CRMBaseTest):
+class ZohoCRMStartDateTest(StartDateTest, ZohoCRMBaseTest):
     """Instantiate start date according to the desired data set and run the
     test."""
 
@@ -12,13 +12,26 @@ class Zoho_CRMStartDateTest(StartDateTest, Zoho_CRMBaseTest):
         return "tap_tester_zoho_crm_start_date_test"
 
     def streams_to_test(self):
-        streams_to_exclude = {}
+        # Exclude streams that don't have enough test data to exceed the page_size
+        streams_to_exclude = {
+            'territories',
+            'functions__s',
+            'organization',
+            'profiles',
+            'roles',
+            'events',
+            'deals',
+            'dealhistory',
+            'notes',
+            'attachments',
+            'currencies'
+        }
         return self.expected_stream_names().difference(streams_to_exclude)
 
     @property
     def start_date_1(self):
-        return "2015-03-25T00:00:00Z"
+        return "2025-01-01T00:00:00Z"
+
     @property
     def start_date_2(self):
-        return "2017-01-25T00:00:00Z"
-
+        return "2025-09-05T00:00:00Z"

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,0 +1,273 @@
+import unittest
+from unittest.mock import patch, MagicMock, call
+from singer.catalog import Catalog
+
+from tap_zoho_crm.discover import discover, _apply_access_checks, _prune_inaccessible_children
+from tap_zoho_crm.exceptions import ZohoCRMForbiddenError
+from tap_zoho_crm.streams import STREAMS
+
+
+def _make_stream_cls(accessible=True, parent=""):
+    """Helper: return a minimal stream class whose instance.check_access() returns `accessible`."""
+    class _MockStreamCls:
+        pass
+    _MockStreamCls.parent = parent
+
+    def __init__(self, client=None):
+        pass
+
+    def check_access(self):
+        return accessible
+
+    _MockStreamCls.__init__ = __init__
+    _MockStreamCls.check_access = check_access
+    return _MockStreamCls
+
+
+class TestApplyAccessChecks(unittest.TestCase):
+    """Tests for _apply_access_checks()."""
+
+    def _make_schemas_and_metadata(self, stream_names=None):
+        names = stream_names or list(STREAMS.keys())
+        schemas = {name: {"type": "object", "properties": {}} for name in names}
+        field_metadata = {name: [] for name in names}
+        return schemas, field_metadata
+
+    def test_all_streams_accessible_leaves_catalog_unchanged(self):
+        """When all streams are accessible, schemas and field_metadata are unchanged."""
+        client = MagicMock()
+        all_names = list(STREAMS.keys())
+        schemas, field_metadata = self._make_schemas_and_metadata(all_names)
+
+        mock_streams = {name: _make_stream_cls(accessible=True) for name in all_names}
+
+        with patch("tap_zoho_crm.discover.STREAMS", mock_streams):
+            _apply_access_checks(client, schemas, field_metadata)
+
+        self.assertEqual(set(schemas.keys()), set(all_names))
+        self.assertEqual(set(field_metadata.keys()), set(all_names))
+
+    def test_inaccessible_stream_removed_from_schemas(self):
+        """A stream returning False from check_access is removed from schemas and field_metadata."""
+        client = MagicMock()
+        all_names = list(STREAMS.keys())
+        schemas, field_metadata = self._make_schemas_and_metadata(all_names)
+
+        inaccessible_name = all_names[0]
+        accessible_names = all_names[1:]
+
+        mock_streams = {
+            name: _make_stream_cls(accessible=(name != inaccessible_name))
+            for name in all_names
+        }
+
+        with patch("tap_zoho_crm.discover.STREAMS", mock_streams):
+            _apply_access_checks(client, schemas, field_metadata)
+
+        self.assertNotIn(inaccessible_name, schemas)
+        self.assertNotIn(inaccessible_name, field_metadata)
+        for name in accessible_names:
+            self.assertIn(name, schemas)
+
+    def test_all_parent_streams_inaccessible_raises_forbidden_error(self):
+        """Raises ZohoCRMForbiddenError when no parent streams are accessible."""
+        client = MagicMock()
+        all_names = list(STREAMS.keys())
+        schemas, field_metadata = self._make_schemas_and_metadata(all_names)
+
+        mock_streams = {name: _make_stream_cls(accessible=False) for name in all_names}
+
+        with patch("tap_zoho_crm.discover.STREAMS", mock_streams):
+            with self.assertRaises(ZohoCRMForbiddenError):
+                _apply_access_checks(client, schemas, field_metadata)
+
+    def test_partial_inaccessibility_logs_warning_without_raising(self):
+        """Logs a warning but does not raise when only some streams are inaccessible."""
+        client = MagicMock()
+        all_names = list(STREAMS.keys())
+        schemas, field_metadata = self._make_schemas_and_metadata(all_names)
+
+        inaccessible_name = all_names[0]
+        mock_streams = {
+            name: _make_stream_cls(accessible=(name != inaccessible_name))
+            for name in all_names
+        }
+
+        with patch("tap_zoho_crm.discover.STREAMS", mock_streams):
+            with patch("tap_zoho_crm.discover.LOGGER") as mock_logger:
+                _apply_access_checks(client, schemas, field_metadata)
+                mock_logger.warning.assert_called_once()
+                warning_msg = mock_logger.warning.call_args[0][0]
+                self.assertIn("excluded from the catalog", warning_msg)
+
+        self.assertNotIn(inaccessible_name, schemas)
+
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """Tests for _prune_inaccessible_children()."""
+
+    def test_child_removed_when_parent_absent(self):
+        """Child stream is removed from catalog when its parent has already been excluded."""
+        schemas = {"child_stream": {}, "other_stream": {}}
+        field_metadata = {"child_stream": [], "other_stream": []}
+
+        mock_streams = {
+            "child_stream": _make_stream_cls(parent="parent_stream"),
+            "other_stream": _make_stream_cls(parent=""),
+        }
+
+        with patch("tap_zoho_crm.discover.STREAMS", mock_streams):
+            with patch("tap_zoho_crm.discover.LOGGER") as mock_logger:
+                _prune_inaccessible_children(schemas, field_metadata)
+                mock_logger.warning.assert_called_once()
+
+        self.assertNotIn("child_stream", schemas)
+        self.assertNotIn("child_stream", field_metadata)
+        self.assertIn("other_stream", schemas)
+
+    def test_child_retained_when_parent_present(self):
+        """Child stream is not removed when its parent is present in schemas."""
+        schemas = {"parent_stream": {}, "child_stream": {}}
+        field_metadata = {"parent_stream": [], "child_stream": []}
+
+        mock_streams = {
+            "parent_stream": _make_stream_cls(parent=""),
+            "child_stream": _make_stream_cls(parent="parent_stream"),
+        }
+
+        with patch("tap_zoho_crm.discover.STREAMS", mock_streams):
+            _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertIn("child_stream", schemas)
+        self.assertIn("parent_stream", schemas)
+
+    def test_no_children_no_changes(self):
+        """When no streams have a parent, schemas remain unchanged."""
+        all_names = list(STREAMS.keys())
+        schemas = {name: {} for name in all_names}
+        field_metadata = {name: [] for name in all_names}
+
+        # All real Zoho CRM streams have parent="" (no parent)
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertEqual(set(schemas.keys()), set(all_names))
+
+
+class TestDiscover(unittest.TestCase):
+    """Tests for discover()."""
+
+    def _make_mock_stream_entry(self, name):
+        entry = MagicMock()
+        entry.stream = name
+        entry.tap_stream_id = name
+        return entry
+
+    @patch("tap_zoho_crm.discover._apply_access_checks")
+    @patch("tap_zoho_crm.discover.get_dynamic_schema")
+    @patch("tap_zoho_crm.discover.get_static_schemas")
+    def test_discover_returns_catalog(self, mock_static, mock_dynamic, mock_access_checks):
+        """discover() returns a Catalog instance containing all streams."""
+        client = MagicMock()
+
+        mock_static.return_value = (
+            {"currencies": {"type": "object", "properties": {"id": {"type": "string"}}}},
+            {"currencies": [{"breadcrumb": [], "metadata": {"table-key-properties": ["id"]}}]},
+        )
+        mock_dynamic.return_value = ({}, {})
+        mock_access_checks.return_value = None  # mutates in place, nothing to remove
+
+        catalog = discover(client)
+
+        self.assertIsInstance(catalog, Catalog)
+        self.assertEqual(len(catalog.streams), 1)
+        self.assertEqual(catalog.streams[0].tap_stream_id, "currencies")
+
+    @patch("tap_zoho_crm.discover._apply_access_checks")
+    @patch("tap_zoho_crm.discover.get_dynamic_schema")
+    @patch("tap_zoho_crm.discover.get_static_schemas")
+    def test_discover_calls_access_checks(self, mock_static, mock_dynamic, mock_access_checks):
+        """discover() calls _apply_access_checks with the client and merged schemas."""
+        client = MagicMock()
+        mock_static.return_value = ({"currencies": {}}, {"currencies": []})
+        mock_dynamic.return_value = ({"leads": {}}, {"leads": []})
+        mock_access_checks.return_value = None
+
+        discover(client)
+
+        mock_access_checks.assert_called_once()
+        call_args = mock_access_checks.call_args[0]
+        self.assertEqual(call_args[0], client)
+        # Both static and dynamic schemas are merged before the check
+        self.assertIn("currencies", call_args[1])
+        self.assertIn("leads", call_args[1])
+
+    @patch("tap_zoho_crm.discover._apply_access_checks")
+    @patch("tap_zoho_crm.discover.get_dynamic_schema")
+    @patch("tap_zoho_crm.discover.get_static_schemas")
+    def test_discover_excludes_streams_removed_by_access_check(
+        self, mock_static, mock_dynamic, mock_access_checks
+    ):
+        """Streams removed from schemas by _apply_access_checks are absent from the catalog."""
+        client = MagicMock()
+        mock_static.return_value = (
+            {
+                "currencies": {"type": "object", "properties": {"id": {"type": "string"}}},
+                "users": {"type": "object", "properties": {"id": {"type": "string"}}},
+            },
+            {
+                "currencies": [{"breadcrumb": [], "metadata": {"table-key-properties": ["id"]}}],
+                "users": [{"breadcrumb": [], "metadata": {"table-key-properties": ["id"]}}],
+            },
+        )
+        mock_dynamic.return_value = ({}, {})
+
+        def remove_currencies(client_arg, schemas, field_metadata):
+            schemas.pop("currencies", None)
+            field_metadata.pop("currencies", None)
+
+        mock_access_checks.side_effect = remove_currencies
+
+        catalog = discover(client)
+
+        stream_ids = [s.tap_stream_id for s in catalog.streams]
+        self.assertNotIn("currencies", stream_ids)
+        self.assertIn("users", stream_ids)
+
+
+class TestCheckAccess(unittest.TestCase):
+    """Tests for BaseStream.check_access()."""
+
+    def _make_stream(self, parent=""):
+        from tap_zoho_crm.streams.currencies import Currencies
+        stream = Currencies.__new__(Currencies)
+        stream.client = MagicMock()
+        stream.parent = parent
+        stream.url_endpoint = ""
+        stream.path = "org/currencies"
+        stream.http_method = "GET"
+        stream.params = {}
+        stream.headers = {"Accept": "application/json"}
+        stream.data_payload = {}
+        return stream
+
+    def test_returns_true_when_request_succeeds(self):
+        stream = self._make_stream()
+        stream.client.make_request.return_value = {}
+
+        self.assertTrue(stream.check_access())
+
+    def test_returns_false_on_forbidden_error(self):
+        stream = self._make_stream()
+        stream.client.make_request.side_effect = ZohoCRMForbiddenError("403")
+
+        self.assertFalse(stream.check_access())
+
+    def test_child_stream_always_returns_true(self):
+        """Child streams bypass the access check and always return True."""
+        stream = self._make_stream(parent="parent_stream")
+        # make_request should never be called for child streams
+        stream.client.make_request.side_effect = ZohoCRMForbiddenError("403")
+
+        self.assertTrue(stream.check_access())
+        stream.client.make_request.assert_not_called()
+

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -98,7 +98,7 @@ class TestApplyAccessChecks(unittest.TestCase):
                 _apply_access_checks(client, schemas, field_metadata)
                 mock_logger.warning.assert_called_once()
                 warning_msg = mock_logger.warning.call_args[0][0]
-                self.assertIn("excluded from the catalog", warning_msg)
+                self.assertIn("Excluded from catalog", warning_msg)
 
         self.assertNotIn(inaccessible_name, schemas)
 


### PR DESCRIPTION
# Description of change
PR includes:
  - `parameterized` moved to `extras_require[dev]` where it will still be installed via `pip install .[dev]` in CI and not included in the production image.
  - Add check_access() to BaseStream; returns False on ZohoCRMForbiddenError.
  - Add _apply_access_checks() and _prune_inaccessible_children() to discover.py.
  - Raise ZohoCRMForbiddenError if no parent streams are accessible at all.
  - Fix BaseStream.__init__ to safely handle catalog=None.
  - Add unit tests for access-check and pruning logic (13 tests).
  - Enable and fixed integration tests.
  - Bump version to 0.1.0.

# Manual QA steps
 - [x]  Discovery: Running
 - [x]  Sync: Running
 - [x]  Unit Tests: Running
 - [x]  Integration test: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch