### PR TITLE
SAC-31570: adding access token chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   * 403-inaccessible streams are now excluded from the catalog during discovery instead of failing entirely. [#9](https://github.com/singer-io/tap-zoho-crm/pull/9)
   * Added unit tests for discovery access-check behavior.
   * Bump singer-python to 6.8.0 and requests to 2.34.2 (CVE-2026-25645)
+  * Implemented access token chaining: valid tokens are reused across runs without an extra refresh round-trip. [#10](https://github.com/singer-io/tap-zoho-crm/pull/10)
 
 ## 0.0.1
   * Initial Commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * Added unit tests for discovery access-check behavior.
   * Bump singer-python to 6.8.0 and requests to 2.34.2 (CVE-2026-25645)
   * Implemented access token chaining: valid tokens are reused across runs without an extra refresh round-trip. [#10](https://github.com/singer-io/tap-zoho-crm/pull/10)
+  * Added `preserve_config = True` to ensure the configuration is preserved when multiple integration tests run concurrently, preventing it from being overwritten or reset between test executions.
 
 ## 0.0.1
   * Initial Commit

--- a/tap_zoho_crm/__init__.py
+++ b/tap_zoho_crm/__init__.py
@@ -35,7 +35,7 @@ def main():
     if parsed_args.state:
         state = parsed_args.state
 
-    with Client(parsed_args.config) as client:
+    with Client(parsed_args.config, config_path=parsed_args.config_path) as client:
         config = parsed_args.config
         if parsed_args.discover:
             do_discover(client=client)

--- a/tap_zoho_crm/client.py
+++ b/tap_zoho_crm/client.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Mapping, Optional, Tuple
 from datetime import datetime, timedelta
-import time
+import json
 
 import backoff
 import requests
@@ -12,6 +12,7 @@ from tap_zoho_crm.exceptions import (
     ERROR_CODE_EXCEPTION_MAPPING,
     ZohoCRMError,
     ZohoCRMRateLimitError,
+    ZohoCRMUnauthorizedError,
     ZohoCRMInternalServerError,
     ZohoCRMServiceUnavailableError
 )
@@ -19,6 +20,7 @@ from tap_zoho_crm.exceptions import (
 LOGGER = get_logger()
 REQUEST_TIMEOUT = 300
 REFRESH_URL = "https://accounts.zoho.com/oauth/v2/token"
+BASE_API_DOMAIN = "https://www.zohoapis.com"
 DEFAULT_EXPIRY_TIME_IN_SECONDS = 3600
 
 def raise_for_error(response: requests.Response) -> None:
@@ -110,28 +112,42 @@ class Client:
      - HTTP Error handling and retry
     """
 
-    def __init__(self, config: Mapping[str, Any]) -> None:
+    def __init__(self, config: Mapping[str, Any], config_path: Optional[str] = None) -> None:
         self.config = config
+        self._config_path = config_path
         self._session = session()
-        self._access_token = None
-        self._expires_at = None
         self._scope = None
-        self._api_domain = "https://www.zohoapis.com"
-        self._token_type = None
+
+        # Load persisted token from config if available
+        self._access_token = config.get("access_token")
+        self._token_type = config.get("token_type", "Bearer")
+        self._api_domain = config.get("api_domain", BASE_API_DOMAIN)
+        self._expires_at = None
+        saved_expiry = config.get("token_expires_at")
+        if saved_expiry:
+            try:
+                self._expires_at = datetime.fromisoformat(saved_expiry)
+            except (ValueError, TypeError):
+                self._expires_at = None
+
         self.base_url = f"{self._api_domain}/crm/v8"
 
         config_request_timeout = config.get("request_timeout")
         self.request_timeout = float(config_request_timeout) if config_request_timeout else REQUEST_TIMEOUT
 
     def __enter__(self):
-        self._refresh_access_token()
+        # Reuse saved token if it is still valid; only refresh when missing or expired
+        if self._access_token and self._expires_at and self._expires_at > datetime.now():
+            LOGGER.info("Reusing existing access token from config (expires at %s).", self._expires_at)
+        else:
+            self._refresh_access_token()
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
         self._session.close()
 
     def _refresh_access_token(self) -> None:
-        """Refreshes the access token."""
+        """Refreshes the access token and persists it to the config file."""
         LOGGER.info("Refreshing Access Token")
         resp_json = self.make_request(
             "POST",
@@ -151,11 +167,34 @@ class Client:
         )
         self._access_token = resp_json.get("access_token")
         self._scope = resp_json.get("scope")
-        self._api_domain = resp_json.get("api_domain")
+        api_domain = resp_json.get("api_domain")
+        if api_domain:
+            self._api_domain = api_domain
+            self.base_url = f"{self._api_domain}/crm/v8"
         self._token_type = resp_json.get("token_type", "Bearer")
         expires_in_seconds = resp_json.get("expires_in", DEFAULT_EXPIRY_TIME_IN_SECONDS)
         self._expires_at = datetime.now() + timedelta(seconds=expires_in_seconds)
-        LOGGER.info("Got refreshed access token")
+        self._save_token_to_config()
+        LOGGER.info("Got refreshed access token (expires at %s).", self._expires_at)
+
+    def _save_token_to_config(self) -> None:
+        """Writes the current access token and expiry back to the config file so
+        subsequent runs can reuse it without an extra round-trip."""
+        if not self._config_path:
+            return
+        try:
+            with open(self._config_path, "r") as fh:
+                config_data = json.load(fh)
+            config_data["access_token"] = self._access_token
+            config_data["token_expires_at"] = self._expires_at.isoformat()
+            config_data["token_type"] = self._token_type
+            if self._api_domain:
+                config_data["api_domain"] = self._api_domain
+            with open(self._config_path, "w") as fh:
+                json.dump(config_data, fh, indent=2)
+            LOGGER.info("Access token saved to config file.")
+        except Exception as exc:  # pragma: no cover
+            LOGGER.warning("Failed to save access token to config file: %s", exc)
 
     def get_access_token(self) -> str:
         """Return access token if available or generate one."""
@@ -198,6 +237,9 @@ class Client:
     ) -> Any:
         """
         Sends an HTTP request to the specified API endpoint.
+
+        If the token expires mid-sync and the API returns 401, the token is
+        refreshed automatically and the request is retried once.
         """
         params = params or {}
         headers = headers or {}
@@ -205,13 +247,27 @@ class Client:
         endpoint = endpoint or f"{self.base_url}/{path}"
         if is_auth_req:
             headers, params = self.authenticate(headers, params)
-        return self.__make_request(
-            method, endpoint,
-            headers=headers,
-            params=params,
-            data=body,
-            timeout=self.request_timeout
-        )
+        try:
+            return self.__make_request(
+                method, endpoint,
+                headers=headers,
+                params=params,
+                data=body,
+                timeout=self.request_timeout
+            )
+        except ZohoCRMUnauthorizedError:
+            if not is_auth_req:
+                raise
+            LOGGER.info("Access token rejected (401). Refreshing token and retrying request.")
+            self._refresh_access_token()
+            headers, params = self.authenticate(headers, params)
+            return self.__make_request(
+                method, endpoint,
+                headers=headers,
+                params=params,
+                data=body,
+                timeout=self.request_timeout
+            )
 
     @backoff.on_exception(
         wait_gen=backoff.expo,

--- a/tap_zoho_crm/client.py
+++ b/tap_zoho_crm/client.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, Mapping, Optional, Tuple
 from datetime import datetime, timedelta
 import json
+import os
+import tempfile
 
 import backoff
 import requests
@@ -126,7 +128,12 @@ class Client:
         saved_expiry = config.get("token_expires_at")
         if saved_expiry:
             try:
-                self._expires_at = datetime.fromisoformat(saved_expiry)
+                # normalise a trailing 'Z' (RFC 3339 / UTC) to '+00:00'
+                # because datetime.fromisoformat() does not accept 'Z' on Python < 3.11.
+                expiry_str = saved_expiry
+                if isinstance(expiry_str, str) and expiry_str.endswith("Z"):
+                    expiry_str = expiry_str[:-1] + "+00:00"
+                self._expires_at = datetime.fromisoformat(expiry_str)
             except (ValueError, TypeError):
                 self._expires_at = None
 
@@ -137,7 +144,7 @@ class Client:
 
     def __enter__(self):
         # Reuse saved token if it is still valid; only refresh when missing or expired
-        if self._access_token and self._expires_at and self._expires_at > datetime.now():
+        if self._access_token and self._expires_at and self._expires_at > datetime.now(tz=self._expires_at.tzinfo):
             LOGGER.info("Reusing existing access token from config (expires at %s).", self._expires_at)
         else:
             self._refresh_access_token()
@@ -190,15 +197,20 @@ class Client:
             config_data["token_type"] = self._token_type
             if self._api_domain:
                 config_data["api_domain"] = self._api_domain
-            with open(self._config_path, "w") as fh:
-                json.dump(config_data, fh, indent=2)
+            config_dir = os.path.dirname(os.path.abspath(self._config_path))
+            with tempfile.NamedTemporaryFile(
+                mode="w", dir=config_dir, delete=False, suffix=".tmp"
+            ) as tmp_fh:
+                tmp_path = tmp_fh.name
+                json.dump(config_data, tmp_fh, indent=2)
+            os.replace(tmp_path, self._config_path)
             LOGGER.info("Access token saved to config file.")
         except Exception as exc:  # pragma: no cover
             LOGGER.warning("Failed to save access token to config file: %s", exc)
 
     def get_access_token(self) -> str:
         """Return access token if available or generate one."""
-        if self._access_token and self._expires_at > datetime.now():
+        if self._access_token and self._expires_at and self._expires_at > datetime.now(tz=self._expires_at.tzinfo):
             return self._access_token
 
         self._refresh_access_token()

--- a/tests/base.py
+++ b/tests/base.py
@@ -13,6 +13,7 @@ class ZohoCRMBaseTest(BaseCase):
     """
     start_date = "2025-01-01T00:00:00Z"
     IS_FORBIDDEN_STREAM = "is-forbidden-stream"
+    preserve_config = True
 
     @staticmethod
     def tap_name():

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,9 +1,13 @@
+import json
+import os
+import tempfile
 import unittest
+from datetime import datetime, timedelta
 from parameterized import parameterized
 import requests
-from unittest.mock import patch, MagicMock
+from unittest.mock import call, mock_open, patch, MagicMock
 from requests.exceptions import Timeout, ConnectionError, ChunkedEncodingError
-from tap_zoho_crm.client import Client
+from tap_zoho_crm.client import Client, BASE_API_DOMAIN, DEFAULT_EXPIRY_TIME_IN_SECONDS
 from tap_zoho_crm.exceptions import (
     ZohoCRMBadRequestError,
     ZohoCRMUnauthorizedError,
@@ -134,3 +138,297 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(mock_request.call_count, 5)
 
+
+# ---------------------------------------------------------------------------
+# Helpers shared by token-chaining tests
+# ---------------------------------------------------------------------------
+
+REFRESH_RESPONSE = {
+    "access_token": "new_access_token",
+    "token_type": "Bearer",
+    "api_domain": "https://www.zohoapis.com",
+    "scope": "ZohoCRM.modules.ALL",
+    "expires_in": 3600,
+}
+
+
+def _make_client(extra_config=None, config_path=None):
+    """Return a Client with minimal config and an optionally pre-seeded token."""
+    cfg = default_config.copy()
+    if extra_config:
+        cfg.update(extra_config)
+    return Client(cfg, config_path=config_path)
+
+
+class TestTokenChaining(unittest.TestCase):
+    """Unit tests for access-token chaining (reuse / refresh / persist)."""
+
+    # ------------------------------------------------------------------
+    # __init__ – loading persisted token from config
+    # ------------------------------------------------------------------
+
+    def test_init_loads_valid_token_from_config(self):
+        """Client picks up a saved token and expiry from the config dict."""
+        future = datetime.now() + timedelta(hours=1)
+        cfg = {
+            "access_token": "saved_token",
+            "token_expires_at": future.isoformat(),
+            "token_type": "Bearer",
+            "api_domain": "https://www.zohoapis.eu",
+        }
+        client = _make_client(extra_config=cfg)
+
+        self.assertEqual(client._access_token, "saved_token")
+        self.assertEqual(client._token_type, "Bearer")
+        self.assertEqual(client._api_domain, "https://www.zohoapis.eu")
+        self.assertAlmostEqual(
+            client._expires_at.timestamp(), future.timestamp(), delta=1
+        )
+
+    def test_init_ignores_malformed_token_expiry(self):
+        """A malformed token_expires_at leaves _expires_at as None."""
+        cfg = {
+            "access_token": "saved_token",
+            "token_expires_at": "NOT-A-DATE",
+        }
+        client = _make_client(extra_config=cfg)
+        self.assertIsNone(client._expires_at)
+
+    def test_init_defaults_api_domain_when_absent(self):
+        """When api_domain is not in config, BASE_API_DOMAIN is used."""
+        client = _make_client()
+        self.assertEqual(client._api_domain, BASE_API_DOMAIN)
+        self.assertTrue(client.base_url.startswith(BASE_API_DOMAIN))
+
+    # ------------------------------------------------------------------
+    # __enter__ – reuse vs refresh decision
+    # ------------------------------------------------------------------
+
+    @patch("tap_zoho_crm.client.Client._refresh_access_token")
+    def test_enter_reuses_valid_token(self, mock_refresh):
+        """__enter__ skips refresh when a valid token is already present."""
+        future = datetime.now() + timedelta(hours=1)
+        cfg = {
+            "access_token": "still_valid",
+            "token_expires_at": future.isoformat(),
+        }
+        client = _make_client(extra_config=cfg)
+        client.__enter__()
+        mock_refresh.assert_not_called()
+
+    @patch("tap_zoho_crm.client.Client._refresh_access_token")
+    def test_enter_refreshes_when_token_missing(self, mock_refresh):
+        """__enter__ calls _refresh_access_token when no token is stored."""
+        client = _make_client()
+        client.__enter__()
+        mock_refresh.assert_called_once()
+
+    @patch("tap_zoho_crm.client.Client._refresh_access_token")
+    def test_enter_refreshes_when_token_expired(self, mock_refresh):
+        """__enter__ calls _refresh_access_token when the stored token is expired."""
+        past = datetime.now() - timedelta(seconds=10)
+        cfg = {
+            "access_token": "expired_token",
+            "token_expires_at": past.isoformat(),
+        }
+        client = _make_client(extra_config=cfg)
+        client.__enter__()
+        mock_refresh.assert_called_once()
+
+    @patch("tap_zoho_crm.client.Client._refresh_access_token")
+    def test_enter_refreshes_when_expires_at_none(self, mock_refresh):
+        """__enter__ calls _refresh_access_token when _expires_at is None."""
+        cfg = {"access_token": "token_no_expiry"}
+        client = _make_client(extra_config=cfg)
+        # _expires_at is None because token_expires_at was not in config
+        client.__enter__()
+        mock_refresh.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # _refresh_access_token – updates internal state and persists
+    # ------------------------------------------------------------------
+
+    @patch("tap_zoho_crm.client.Client._save_token_to_config")
+    @patch("tap_zoho_crm.client.Client.make_request", return_value=REFRESH_RESPONSE)
+    def test_refresh_updates_internal_state(self, mock_req, mock_save):
+        """_refresh_access_token stores new token, expiry, domain, and type."""
+        client = _make_client()
+        client._refresh_access_token()
+
+        self.assertEqual(client._access_token, "new_access_token")
+        self.assertEqual(client._token_type, "Bearer")
+        self.assertEqual(client._api_domain, "https://www.zohoapis.com")
+        self.assertIsNotNone(client._expires_at)
+        self.assertGreater(client._expires_at, datetime.now())
+
+    @patch("tap_zoho_crm.client.Client._save_token_to_config")
+    @patch("tap_zoho_crm.client.Client.make_request", return_value=REFRESH_RESPONSE)
+    def test_refresh_calls_save(self, mock_req, mock_save):
+        """_refresh_access_token must call _save_token_to_config."""
+        client = _make_client()
+        client._refresh_access_token()
+        mock_save.assert_called_once()
+
+    @patch("tap_zoho_crm.client.Client._save_token_to_config")
+    @patch("tap_zoho_crm.client.Client.make_request", return_value={**REFRESH_RESPONSE, "api_domain": "https://www.zohoapis.eu"})
+    def test_refresh_updates_base_url_on_domain_change(self, mock_req, mock_save):
+        """base_url is updated when api_domain changes during refresh."""
+        client = _make_client()
+        client._refresh_access_token()
+        self.assertEqual(client._api_domain, "https://www.zohoapis.eu")
+        self.assertEqual(client.base_url, "https://www.zohoapis.eu/crm/v8")
+
+    @patch("tap_zoho_crm.client.Client._save_token_to_config")
+    @patch("tap_zoho_crm.client.Client.make_request", return_value={k: v for k, v in REFRESH_RESPONSE.items() if k != "api_domain"})
+    def test_refresh_keeps_existing_domain_when_absent_in_response(self, mock_req, mock_save):
+        """base_url is unchanged when api_domain is absent from token response."""
+        client = _make_client()
+        client._api_domain = "https://www.zohoapis.eu"
+        client._refresh_access_token()
+        self.assertEqual(client._api_domain, "https://www.zohoapis.eu")
+
+    # ------------------------------------------------------------------
+    # _save_token_to_config
+    # ------------------------------------------------------------------
+
+    def test_save_token_writes_correct_fields(self):
+        """_save_token_to_config writes access_token, expiry, type, domain."""
+        future = datetime.now() + timedelta(hours=1)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as fh:
+            json.dump(default_config.copy(), fh)
+            tmp_path = fh.name
+
+        try:
+            client = _make_client(config_path=tmp_path)
+            client._access_token = "saved_token"
+            client._expires_at = future
+            client._token_type = "Bearer"
+            client._api_domain = "https://www.zohoapis.com"
+            client._save_token_to_config()
+
+            with open(tmp_path) as fh:
+                saved = json.load(fh)
+
+            self.assertEqual(saved["access_token"], "saved_token")
+            self.assertEqual(saved["token_expires_at"], future.isoformat())
+            self.assertEqual(saved["token_type"], "Bearer")
+            self.assertEqual(saved["api_domain"], "https://www.zohoapis.com")
+        finally:
+            os.unlink(tmp_path)
+
+    def test_save_token_no_op_when_config_path_absent(self):
+        """_save_token_to_config does nothing when config_path is None."""
+        client = _make_client(config_path=None)
+        client._access_token = "token"
+        client._expires_at = datetime.now() + timedelta(hours=1)
+        # Should complete without raising even though there is no file
+        client._save_token_to_config()
+
+    def test_save_token_logs_warning_on_io_error(self):
+        """_save_token_to_config logs a warning when the file cannot be written."""
+        client = _make_client(config_path="/nonexistent/path/config.json")
+        client._access_token = "token"
+        client._expires_at = datetime.now() + timedelta(hours=1)
+        client._token_type = "Bearer"
+        # Should not raise — just log a warning
+        client._save_token_to_config()
+
+    # ------------------------------------------------------------------
+    # get_access_token – lazy refresh
+    # ------------------------------------------------------------------
+
+    @patch("tap_zoho_crm.client.Client._refresh_access_token")
+    def test_get_access_token_returns_cached_token(self, mock_refresh):
+        """get_access_token returns the cached token without refreshing."""
+        future = datetime.now() + timedelta(hours=1)
+        cfg = {"access_token": "cached", "token_expires_at": future.isoformat()}
+        client = _make_client(extra_config=cfg)
+        token = client.get_access_token()
+        self.assertEqual(token, "cached")
+        mock_refresh.assert_not_called()
+
+    @patch("tap_zoho_crm.client.Client._refresh_access_token")
+    def test_get_access_token_refreshes_when_expired(self, mock_refresh):
+        """get_access_token triggers refresh when _expires_at is in the past."""
+        past = datetime.now() - timedelta(seconds=10)
+        cfg = {"access_token": "old_token", "token_expires_at": past.isoformat()}
+        client = _make_client(extra_config=cfg)
+
+        def set_new_token():
+            client._access_token = "fresh_token"
+            client._expires_at = datetime.now() + timedelta(hours=1)
+
+        mock_refresh.side_effect = set_new_token
+        token = client.get_access_token()
+        mock_refresh.assert_called_once()
+        self.assertEqual(token, "fresh_token")
+
+    # ------------------------------------------------------------------
+    # make_request – mid-sync 401 retry
+    # ------------------------------------------------------------------
+
+    @patch("tap_zoho_crm.client.Client._refresh_access_token")
+    @patch("tap_zoho_crm.client.Client._Client__make_request")
+    def test_make_request_retries_on_401(self, mock_inner, mock_refresh):
+        """make_request catches ZohoCRMUnauthorizedError, refreshes, and retries."""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+
+        # First call raises 401; second call succeeds
+        mock_inner.side_effect = [
+            ZohoCRMUnauthorizedError("401", mock_response),
+            {"data": "ok"},
+        ]
+
+        client = _make_client()
+        client._access_token = "old_token"
+        client._expires_at = datetime.now() + timedelta(hours=1)
+        client._token_type = "Bearer"
+        client.authenticate = MagicMock(return_value=({"Authorization": "Bearer new"}, {}))
+
+        result = client.make_request("GET", "https://api.example.com/resource")
+
+        self.assertEqual(result, {"data": "ok"})
+        mock_refresh.assert_called_once()
+        self.assertEqual(mock_inner.call_count, 2)
+
+    @patch("tap_zoho_crm.client.Client._refresh_access_token")
+    @patch("tap_zoho_crm.client.Client._Client__make_request")
+    def test_make_request_does_not_retry_401_on_non_auth_request(self, mock_inner, mock_refresh):
+        """401 on a non-authenticated request (is_auth_req=False) is re-raised immediately."""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_inner.side_effect = ZohoCRMUnauthorizedError("401", mock_response)
+
+        client = _make_client()
+
+        with self.assertRaises(ZohoCRMUnauthorizedError):
+            client.make_request(
+                "POST",
+                "https://accounts.zoho.com/oauth/v2/token",
+                is_auth_req=False,
+            )
+
+        mock_refresh.assert_not_called()
+        self.assertEqual(mock_inner.call_count, 1)
+
+    @patch("tap_zoho_crm.client.Client._refresh_access_token")
+    @patch("tap_zoho_crm.client.Client._Client__make_request")
+    def test_make_request_propagates_401_on_retry_failure(self, mock_inner, mock_refresh):
+        """If the retried request also returns 401 it propagates to the caller."""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_inner.side_effect = ZohoCRMUnauthorizedError("401", mock_response)
+
+        client = _make_client()
+        client._access_token = "old_token"
+        client._expires_at = datetime.now() + timedelta(hours=1)
+        client._token_type = "Bearer"
+        client.authenticate = MagicMock(return_value=({"Authorization": "Bearer new"}, {}))
+
+        with self.assertRaises(ZohoCRMUnauthorizedError):
+            client.make_request("GET", "https://api.example.com/resource")
+
+        # First attempt + one retry = 2 calls; refresh attempted once
+        self.assertEqual(mock_inner.call_count, 2)
+        mock_refresh.assert_called_once()

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -5,9 +5,9 @@ import unittest
 from datetime import datetime, timedelta
 from parameterized import parameterized
 import requests
-from unittest.mock import call, mock_open, patch, MagicMock
+from unittest.mock import patch, MagicMock
 from requests.exceptions import Timeout, ConnectionError, ChunkedEncodingError
-from tap_zoho_crm.client import Client, BASE_API_DOMAIN, DEFAULT_EXPIRY_TIME_IN_SECONDS
+from tap_zoho_crm.client import Client, BASE_API_DOMAIN
 from tap_zoho_crm.exceptions import (
     ZohoCRMBadRequestError,
     ZohoCRMUnauthorizedError,
@@ -193,6 +193,39 @@ class TestTokenChaining(unittest.TestCase):
         }
         client = _make_client(extra_config=cfg)
         self.assertIsNone(client._expires_at)
+
+    def test_init_parses_token_expiry_with_trailing_z(self):
+        """token_expires_at ending in 'Z' (RFC 3339) is parsed correctly."""
+        cfg = {
+            "access_token": "saved_token",
+            "token_expires_at": "2099-01-01T00:00:00Z",
+        }
+        client = _make_client(extra_config=cfg)
+        self.assertIsNotNone(client._expires_at)
+        self.assertEqual(client._expires_at.utcoffset().total_seconds(), 0)
+
+    def test_init_ignores_non_string_token_expiry(self):
+        """A non-string token_expires_at (e.g. integer) leaves _expires_at as None."""
+        cfg = {
+            "access_token": "saved_token",
+            "token_expires_at": 1234567890,
+        }
+        client = _make_client(extra_config=cfg)
+        self.assertIsNone(client._expires_at)
+
+    @patch("tap_zoho_crm.client.Client._refresh_access_token")
+    def test_enter_does_not_raise_with_tz_aware_expiry(self, mock_refresh):
+        """__enter__ does not raise TypeError when _expires_at is timezone-aware."""
+        from datetime import timezone
+        future = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+        cfg = {
+            "access_token": "still_valid",
+            "token_expires_at": future.isoformat(),
+        }
+        client = _make_client(extra_config=cfg)
+        # Should not raise "can't compare offset-naive and offset-aware datetimes"
+        client.__enter__()
+        mock_refresh.assert_not_called()
 
     def test_init_defaults_api_domain_when_absent(self):
         """When api_domain is not in config, BASE_API_DOMAIN is used."""


### PR DESCRIPTION
# Description of change
Adds “access token chaining” to the tap so it can reuse a previously refreshed access token across runs (and refresh/retry automatically on mid-sync 401s), reducing unnecessary refresh round-trips.  [SAC-31570](https://qlik-dev.atlassian.net/browse/SAC-31570)

Changes:
- Persist refreshed access token + expiry (+ optional api_domain / token_type) back to the config file and reuse it when still valid.
- Retry authenticated requests once on 401 by refreshing the token and re-authenticating.
- Add unit tests covering init/load, reuse-vs-refresh behavior, persistence, and 401 retry; update changelog entry.

# Manual QA steps
 - [x]  Discovery: Running
 - [x]  Sync: Running
 - [x]  Unit Tests: Running
 - [x]  Integration test: Running

# Risks
 - 
 
# Rollback steps
 - revert this branch
